### PR TITLE
feature: add XAPK sideloading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ installing drivers** - Just download and run!
 
 ## Downloading
 
-1. Go to the [Latest Release](https://github.com/ryan-andrew/android_sideloader/releases/latest)
+1. Go to the [Latest Release](https://github.com/allea/Android-SideHustle/releases/latest)
 2. Choose one of the following from the `Assets` dropdown
    - **Windows**
      - `AndroidSideloader-v*.*.*-Windows-Installer.exe` (_Recommended_)
@@ -220,7 +220,7 @@ be done by doing the following ([From Apple support](https://support.apple.com/g
 
 ### Something else
 
-If you have any other problems, please [create an issue](https://github.com/ryan-andrew/android_sideloader/issues/new).
+If you have any other problems, please [create an issue](https://github.com/allea/Android-SideHustle/issues/new).
 Please also attach the logs to the issue. Logs can be saved via the first button on the bottom right of the app:
 
 <img src="docs/images/save_logs.png" alt="See it in action" width="400"/>

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Android Sideloader is a portable app that lets you very easily sideload apps ont
 Just:
 1. Open Android Sideloader
 2. Select your device
-3. Choose an APK file (or drag and drop one)
-4. Click `Install APK`
+3. Choose an APK or XAPK file (or drag and drop one)
+4. Click `Install`
 
 That's it! The entire process only takes a few seconds. **No command lines, no installing SDKs, no installing ADB, no
 installing drivers** - Just download and run!
@@ -21,6 +21,13 @@ installing drivers** - Just download and run!
 #### See it in action:
 
 <img src="docs/videos/demo2.gif" alt="See it in action" width="800"/>
+
+## Features
+
+- **APK Installation** - Install standard Android APK files
+- **XAPK Support** - Install XAPK packages (split APKs + OBB data files) automatically
+- **Drag & Drop** - Simply drag files into the window
+- **No Setup Required** - Bundled ADB, no SDK or drivers needed
 
 ## Table of Contents
 
@@ -159,22 +166,24 @@ be done by doing the following ([From Apple support](https://support.apple.com/g
       <figcaption><em>Devices appear in "Connected Devices" list</em></figcaption>
     </figure>
 
-3. Choose an APK file (or drag and drop one)
+3. Choose an APK or XAPK file (or drag and drop one)
 
     <figure>
-      <img src="docs/images/demo-select-apk.png" alt="A file browser window will appear where you can select the APK file you want to install" width="400"/>
+      <img src="docs/images/demo-select-apk.png" alt="A file browser window will appear where you can select the APK or XAPK file you want to install" width="400"/>
       <br>
-      <figcaption><em>A file browser window will appear where you can select the APK file you want to install</em></figcaption>
+      <figcaption><em>A file browser window will appear where you can select the APK or XAPK file you want to install</em></figcaption>
     </figure>
     <br>
     <br>
     <figure>
-      <img src="docs/images/demo-drag-apk.png" alt="You can also just drag and drop your APK file into the Android Sideloader window at any time" width="400"/>
+      <img src="docs/images/demo-drag-apk.png" alt="You can also just drag and drop your APK/XAPK file into the Android Sideloader window at any time" width="400"/>
       <br>
-      <figcaption><em>You can also just drag and drop your APK file into the Android Sideloader window at any time</em></figcaption>
+      <figcaption><em>You can also just drag and drop your APK/XAPK file into the Android Sideloader window at any time</em></figcaption>
     </figure>
 
-4. Click `Install APK`
+    > **What is XAPK?** XAPK is a package format that bundles split APKs and OBB expansion files together. Android Sideloader automatically extracts and installs all components.
+
+4. Click `Install`
 
     <figure>
       <img src="docs/images/demo-install-apk.png" alt="" width="400"/>

--- a/docs/changelogs/xapk-support.md
+++ b/docs/changelogs/xapk-support.md
@@ -1,0 +1,76 @@
+# XAPK Sideloading Support
+
+## Overview
+
+Added support for XAPK file format installation. XAPK is a ZIP-based package format that can contain:
+- **base.apk** - The main APK file
+- **Split APKs** - Architecture/language specific APKs (e.g., config.arm64_v8a.apk)
+- **OBB files** - Expansion data files
+- **manifest.json** - Package metadata
+
+## New Files
+
+| File | Description |
+|------|-------------|
+| `lib/xapk/xapk_manifest.dart` | Data model for parsing manifest.json |
+| `lib/xapk/xapk_parser.dart` | XAPK extraction and parsing logic |
+| `lib/xapk/xapk_installer.dart` | Installation flow controller with progress tracking |
+| `lib/ui/install_progress_dialog.dart` | Progress dialog UI for XAPK installation |
+
+## Modified Files
+
+### `pubspec.yaml`
+- Added `archive: ^3.6.1` dependency for ZIP extraction
+
+### `lib/adb/adb.dart`
+- Added `installMultiple()` method for split APK installation using `adb install-multiple`
+- Added `pushFile()` method for pushing files to device using `adb push`
+- Added `pushObbFiles()` method for batch OBB file pushing with progress callback
+
+### `lib/ui/drag_and_drop_apk.dart`
+- Added `PackageType` enum (`apk`, `xapk`)
+- Extended drop handler to accept `.xapk` files
+- Updated callback signature to include file type
+
+### `lib/ui/home_screen.dart`
+- Added `_selectedFileType` state variable
+- Extended file picker to accept both `.apk` and `.xapk` extensions
+- Added `_installXapk()` method with progress dialog
+- Updated UI to show different icons and labels for XAPK files
+
+### `lib/util/file_path.dart`
+- Added `createTempSubDir()` for creating temporary directories
+- Added `cleanupTempDir()` for cleaning up specific directories
+- Added `cleanupAllXapkTemp()` for cleaning all XAPK temporary files
+
+## Installation Flow
+
+```
+1. User selects/drops XAPK file
+       ↓
+2. Progress dialog appears
+       ↓
+3. Parse XAPK (extract to temp directory)
+       ↓
+4. Install APKs (adb install-multiple)
+       ↓
+5. Push OBB files if present (adb push)
+       ↓
+6. Cleanup temporary files
+       ↓
+7. Show result
+```
+
+## Error Handling
+
+| Error | Handling |
+|-------|----------|
+| Invalid XAPK format | Show "Invalid XAPK format" error |
+| Missing manifest.json | Show format error |
+| APK installation failed | Show ADB error message |
+| OBB push failed | Warning only (APK already installed) |
+| Disk space insufficient | Show IO error |
+
+## Bug Fixes
+
+- Fixed `version_code` parsing to handle both integer and string types in manifest.json

--- a/lib/adb/adb.dart
+++ b/lib/adb/adb.dart
@@ -103,12 +103,120 @@ class Adb {
     } on ShellException catch (shellException, stackTrace) {
       Log.e(
         "Error starting ADB server.\n"
-          "* stdout:\n${shellException.result?.outText}\n" 
-          "* stderr:\n${shellException.result?.errText}", 
-        error: shellException, 
+          "* stdout:\n${shellException.result?.outText}\n"
+          "* stderr:\n${shellException.result?.errText}",
+        error: shellException,
         stackTrace: stackTrace
       );
       return false;
     }
+  }
+
+  /// Install multiple APKs using adb install-multiple (for Split APKs)
+  static Future<void> installMultiple({
+    required List<String> filePaths,
+    String? device,
+    required void Function(String outText) onSuccess,
+    required void Function(String errorMessage) onFailure,
+  }) async {
+    if (filePaths.isEmpty) {
+      onFailure("No APK files provided");
+      return;
+    }
+
+    // If only one file, use regular install
+    if (filePaths.length == 1) {
+      return installAPK(
+        filePath: filePaths.first,
+        device: device,
+        onSuccess: onSuccess,
+        onFailure: onFailure,
+      );
+    }
+
+    try {
+      Log.i("Installing ${filePaths.length} APKs using install-multiple");
+
+      // Build command: adb install-multiple "file1.apk" "file2.apk" ...
+      final quotedPaths = filePaths.map((p) => '"$p"').join(' ');
+      final command = '"${await AdbPath.adbPath}" '
+          '${device != null ? "-s $device " : ""}'
+          'install-multiple $quotedPaths';
+
+      final result = await (await _shell).run(command);
+      Log.i("Successfully installed multiple APKs:\n${result.outText}");
+      onSuccess(result.outText);
+    } on ShellException catch (shellException, stackTrace) {
+      Log.e(
+        "Error installing multiple APKs.\n"
+          "* stdout:\n${shellException.result?.outText}\n"
+          "* stderr:\n${shellException.result?.errText}",
+        error: shellException,
+        stackTrace: stackTrace
+      );
+      onFailure("Error: $shellException");
+    }
+  }
+
+  /// Push a file to the device
+  static Future<bool> pushFile({
+    required String localPath,
+    required String remotePath,
+    String? device,
+  }) async {
+    try {
+      Log.i("Pushing file: $localPath -> $remotePath");
+
+      // Create target directory first
+      final remoteDir = remotePath.substring(0, remotePath.lastIndexOf('/'));
+      await (await _shell).run(
+        '"${await AdbPath.adbPath}" '
+        '${device != null ? "-s $device " : ""}'
+        'shell mkdir -p "$remoteDir"'
+      );
+
+      // Push file
+      final result = await (await _shell).run(
+        '"${await AdbPath.adbPath}" '
+        '${device != null ? "-s $device " : ""}'
+        'push "$localPath" "$remotePath"'
+      );
+
+      Log.i("Successfully pushed file:\n${result.outText}");
+      return true;
+    } on ShellException catch (shellException, stackTrace) {
+      Log.e(
+        "Error pushing file.\n"
+          "* stdout:\n${shellException.result?.outText}\n"
+          "* stderr:\n${shellException.result?.errText}",
+        error: shellException,
+        stackTrace: stackTrace
+      );
+      return false;
+    }
+  }
+
+  /// Push multiple OBB files
+  static Future<bool> pushObbFiles({
+    required List<({String localPath, String remotePath})> files,
+    String? device,
+    void Function(int current, int total, String fileName)? onProgress,
+  }) async {
+    for (var i = 0; i < files.length; i++) {
+      final file = files[i];
+      onProgress?.call(i + 1, files.length, file.localPath.split('/').last);
+
+      final success = await pushFile(
+        localPath: file.localPath,
+        remotePath: file.remotePath,
+        device: device,
+      );
+
+      if (!success) {
+        Log.e("Failed to push OBB file: ${file.localPath}");
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:android_sideloader/logs/log.dart';
+import 'package:android_sideloader/services/preferences.dart';
 import 'package:android_sideloader/ui/home_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
@@ -6,6 +7,7 @@ import 'package:window_manager/window_manager.dart';
 
 void main() async => await Log.init(level: Level.all, () async {
   Log.i("Logging initialized. Starting app...");
+  await Preferences.init();
   await windowManager.ensureInitialized();
 
   windowManager.waitUntilReadyToShow(

--- a/lib/services/preferences.dart
+++ b/lib/services/preferences.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Preferences {
+  static const _keyShowSerialNumber = 'show_serial_number';
+
+  static SharedPreferences? _prefs;
+
+  static Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
+
+  static bool get showSerialNumber {
+    return _prefs?.getBool(_keyShowSerialNumber) ?? true;
+  }
+
+  static Future<void> setShowSerialNumber(bool value) async {
+    await _prefs?.setBool(_keyShowSerialNumber, value);
+  }
+}

--- a/lib/ui/device_list_item.dart
+++ b/lib/ui/device_list_item.dart
@@ -4,8 +4,13 @@ import 'package:flutter/material.dart';
 
 class DeviceListItem extends StatelessWidget {
   final AdbDevice device;
+  final bool showSerialNumber;
 
-  const DeviceListItem({super.key, required this.device});
+  const DeviceListItem({
+    super.key,
+    required this.device,
+    this.showSerialNumber = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -30,14 +35,15 @@ class DeviceListItem extends StatelessWidget {
                 ),
                 overflow: TextOverflow.ellipsis,
               ),
-              Text(
-                device.id,
-                style: TextStyle(
-                  color: theme.colorScheme.onSurface.withAlpha(200),
-                  fontSize: theme.textTheme.bodySmall?.fontSize,
+              if (showSerialNumber)
+                Text(
+                  device.id,
+                  style: TextStyle(
+                    color: theme.colorScheme.onSurface.withAlpha(200),
+                    fontSize: theme.textTheme.bodySmall?.fontSize,
+                  ),
+                  overflow: TextOverflow.ellipsis,
                 ),
-                overflow: TextOverflow.ellipsis,
-              ),
             ],
           ),
         ),

--- a/lib/ui/device_list_widget.dart
+++ b/lib/ui/device_list_widget.dart
@@ -7,8 +7,13 @@ import '../logs/log.dart';
 
 class DeviceListWidget extends StatefulWidget {
   final void Function(AdbDevice? selectedDevice) onDeviceSelected;
+  final bool showSerialNumber;
 
-  const DeviceListWidget({super.key, required this.onDeviceSelected});
+  const DeviceListWidget({
+    super.key,
+    required this.onDeviceSelected,
+    this.showSerialNumber = true,
+  });
 
   @override
   State<DeviceListWidget> createState() => _DeviceListWidgetState();
@@ -110,7 +115,10 @@ class _DeviceListWidgetState extends State<DeviceListWidget> {
                               vertical: 8.0,
                               horizontal: 8.0
                           ),
-                          child: DeviceListItem(device: device)
+                          child: DeviceListItem(
+                            device: device,
+                            showSerialNumber: widget.showSerialNumber,
+                          )
                         ),
                       );
                     },

--- a/lib/ui/drag_and_drop_apk.dart
+++ b/lib/ui/drag_and_drop_apk.dart
@@ -3,12 +3,17 @@ import 'package:flutter/material.dart';
 
 import '../logs/log.dart';
 
+/// Supported package types
+enum PackageType { apk, xapk }
+
 class DragAndDropApk extends StatefulWidget {
   final Widget child;
-  final Function(String) onApkDropped;
+  final Function(String path, PackageType type) onPackageDropped;
 
   const DragAndDropApk({
-    super.key, required this.child, required this.onApkDropped,
+    super.key,
+    required this.child,
+    required this.onPackageDropped,
   });
 
   @override
@@ -37,8 +42,12 @@ class _DragAndDropApkState extends State<DragAndDropApk> {
         Log.d("onDragDone");
         if (details.files.isNotEmpty) {
           final file = details.files.first;
-          if (file.name.toLowerCase().endsWith('.apk')) {
-            _handleApkDropped(file.path);
+          final fileName = file.name.toLowerCase();
+
+          if (fileName.endsWith('.apk')) {
+            _handlePackageDropped(file.path, PackageType.apk);
+          } else if (fileName.endsWith('.xapk')) {
+            _handlePackageDropped(file.path, PackageType.xapk);
           } else {
             _handleInvalidFileDropped();
           }
@@ -73,7 +82,7 @@ class _DragAndDropApkState extends State<DragAndDropApk> {
                           ),
                           const SizedBox(height: 20),
                           Text(
-                            'Drag and drop your APK file here',
+                            'Drag and drop your APK or XAPK file here',
                             style: Theme.of(context).textTheme.bodyLarge,
                             textAlign: TextAlign.center,
                           ),
@@ -89,9 +98,9 @@ class _DragAndDropApkState extends State<DragAndDropApk> {
     );
   }
 
-  void _handleApkDropped(String filePath) {
-    Log.i("APK file dropped: $filePath");
-    widget.onApkDropped(filePath);
+  void _handlePackageDropped(String filePath, PackageType type) {
+    Log.i("${type.name.toUpperCase()} file dropped: $filePath");
+    widget.onPackageDropped(filePath, type);
     setState(() {
       _isDragging = false;
     });
@@ -107,7 +116,8 @@ class _DragAndDropApkState extends State<DragAndDropApk> {
         ),
         icon: const Icon(Icons.warning_rounded, color: Colors.orange, size: 48),
         title: const Text('Invalid File'),
-        content: const Text('You can only drag and drop APK files here',
+        content: const Text(
+          'You can only drag and drop APK or XAPK files here',
           textAlign: TextAlign.center,
         ),
         actions: [

--- a/lib/ui/home_screen.dart
+++ b/lib/ui/home_screen.dart
@@ -9,10 +9,12 @@ import '../adb/adb.dart';
 import '../adb/adb_device.dart';
 import '../logs/log.dart';
 import '../logs/save_logs_button.dart';
+import '../services/preferences.dart';
 import '../xapk/xapk_installer.dart';
 import 'device_list_widget.dart';
 import 'drag_and_drop_apk.dart';
 import 'install_progress_dialog.dart';
+import 'settings_dialog.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -25,6 +27,7 @@ class _HomeScreenState extends State<HomeScreen> {
   AdbDevice? _selectedDevice;
   String? _selectedFile;
   PackageType? _selectedFileType;
+  bool _showSerialNumber = Preferences.showSerialNumber;
 
   String? get _selectedFileName =>
       _selectedFile?.split(Platform.pathSeparator).last;
@@ -115,7 +118,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void _launchHelpURL() async {
     final Uri url = Uri.parse(
-        'https://github.com/ryan-andrew/android_sideloader?tab=readme-ov-file#android-sideloader');
+        'https://github.com/allea/Android-SideHustle/discussions');
     if (!await launchUrl(url)) {
       throw 'Could not launch $url';
     }
@@ -139,6 +142,21 @@ class _HomeScreenState extends State<HomeScreen> {
             const SaveLogButton(),
             const SizedBox(width: 8),
             Tooltip(
+              message: "Settings",
+              child: IconButton(
+                onPressed: () => SettingsDialog.show(
+                  context,
+                  onSettingsChanged: () {
+                    setState(() {
+                      _showSerialNumber = Preferences.showSerialNumber;
+                    });
+                  },
+                ),
+                icon: const Icon(Icons.settings),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Tooltip(
               message: "More Information",
               child: IconButton(
                 onPressed: () => _launchHelpURL(),
@@ -150,6 +168,7 @@ class _HomeScreenState extends State<HomeScreen> {
         body: Row(
           children: [
             DeviceListWidget(
+              showSerialNumber: _showSerialNumber,
               onDeviceSelected: (device) {
                 Log.i("Selected device $device");
                 WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/ui/home_screen.dart
+++ b/lib/ui/home_screen.dart
@@ -9,8 +9,10 @@ import '../adb/adb.dart';
 import '../adb/adb_device.dart';
 import '../logs/log.dart';
 import '../logs/save_logs_button.dart';
+import '../xapk/xapk_installer.dart';
 import 'device_list_widget.dart';
 import 'drag_and_drop_apk.dart';
+import 'install_progress_dialog.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -22,63 +24,98 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   AdbDevice? _selectedDevice;
   String? _selectedFile;
+  PackageType? _selectedFileType;
+
   String? get _selectedFileName =>
-      _selectedFile!.split(Platform.pathSeparator).last;
-  bool get _isButtonEnabled => _selectedDevice != null && _selectedFile != null;
+      _selectedFile?.split(Platform.pathSeparator).last;
+
+  bool get _isButtonEnabled =>
+      _selectedDevice != null && _selectedFile != null;
+
+  bool get _isXapk => _selectedFileType == PackageType.xapk;
 
   Future<void> _pickFile() async {
     FilePickerResult? result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
-      allowedExtensions: ['apk'],
+      allowedExtensions: ['apk', 'xapk'],
     );
 
     final path = result?.files.single.path;
     if (path != null) {
+      final isXapk = path.toLowerCase().endsWith('.xapk');
       setState(() {
         _selectedFile = path;
-        Log.i("Selected APK file $_selectedFile");
+        _selectedFileType = isXapk ? PackageType.xapk : PackageType.apk;
+        Log.i("Selected ${isXapk ? 'XAPK' : 'APK'} file: $_selectedFile");
       });
     } else {
       Log.w("Did not pick good file: $result");
     }
   }
 
-  Future<void> _installAPK() async {
+  Future<void> _install() async {
     final selectedFile = _selectedFile;
     final deviceId = _selectedDevice?.id;
     if (selectedFile == null || deviceId == null) {
       return;
     }
+
+    if (_isXapk) {
+      await _installXapk(selectedFile, deviceId);
+    } else {
+      await _installApk(selectedFile, deviceId);
+    }
+  }
+
+  Future<void> _installApk(String filePath, String deviceId) async {
     Adb.installAPK(
       device: deviceId,
-      filePath: selectedFile,
+      filePath: filePath,
       onSuccess: (outText) {
         Log.i("Successfully installed APK file $_selectedFile:\n$outText");
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('App successfully installed!'),
-            ),
-          );
-        }
+        _showSnackBar('App successfully installed!', isError: false);
       },
       onFailure: (errorMessage) {
         Log.w("Failed to install APK file $_selectedFile:\n$errorMessage");
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Failed to install app: $errorMessage'),
-            ),
-          );
-        }
+        _showSnackBar('Failed to install app: $errorMessage', isError: true);
       },
     );
   }
 
+  Future<void> _installXapk(String filePath, String deviceId) async {
+    final result = await InstallProgressDialog.show(
+      context: context,
+      fileName: _selectedFileName ?? 'XAPK',
+      installer: (onProgress) => XapkInstaller.install(
+        xapkPath: filePath,
+        deviceId: deviceId,
+        onSuccess: (msg) => Log.i("XAPK installed: $msg"),
+        onFailure: (err) => Log.e("XAPK install failed: $err"),
+        onProgress: onProgress,
+      ),
+    );
+
+    if (result == true) {
+      _showSnackBar('XAPK successfully installed!', isError: false);
+    } else if (result == false) {
+      _showSnackBar('Failed to install XAPK', isError: true);
+    }
+  }
+
+  void _showSnackBar(String message, {required bool isError}) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: isError ? Colors.red.shade700 : null,
+        ),
+      );
+    }
+  }
+
   void _launchHelpURL() async {
     final Uri url = Uri.parse(
-      'https://github.com/ryan-andrew/android_sideloader?tab=readme-ov-file#android-sideloader'
-    );
+        'https://github.com/ryan-andrew/android_sideloader?tab=readme-ov-file#android-sideloader');
     if (!await launchUrl(url)) {
       throw 'Could not launch $url';
     }
@@ -88,8 +125,11 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return DragAndDropApk(
-      onApkDropped: (String s) {
-        setState(() => _selectedFile = s );
+      onPackageDropped: (String path, PackageType type) {
+        setState(() {
+          _selectedFile = path;
+          _selectedFileType = type;
+        });
       },
       child: Scaffold(
         floatingActionButton: Row(
@@ -122,29 +162,19 @@ class _HomeScreenState extends State<HomeScreen> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text(
-                      _selectedFile == null
-                        ? 'No file selected'
-                        : 'Selected File: $_selectedFileName',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(
-                        color: _selectedFile == null
-                          ? Colors.red.lerp(theme.colorScheme.onSurface, 0.3)
-                          : Colors.green.lerp(theme.colorScheme.onSurface, 0.3),
-                      ),
-                    ),
+                    _buildFileStatus(theme),
                     const SizedBox(height: 40),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         ElevatedButton(
                           onPressed: _pickFile,
-                          child: const Text('Choose APK File'),
+                          child: const Text('Choose APK/XAPK File'),
                         ),
                         const SizedBox(width: 40),
                         ElevatedButton(
-                          onPressed: _isButtonEnabled ? _installAPK : null,
-                          child: const Text('Install APK'),
+                          onPressed: _isButtonEnabled ? _install : null,
+                          child: Text(_isXapk ? 'Install XAPK' : 'Install APK'),
                         ),
                       ],
                     ),
@@ -155,6 +185,51 @@ class _HomeScreenState extends State<HomeScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildFileStatus(ThemeData theme) {
+    if (_selectedFile == null) {
+      return Text(
+        'No file selected',
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          color: Colors.red.lerp(theme.colorScheme.onSurface, 0.3),
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              _isXapk ? Icons.folder_zip : Icons.android,
+              size: 20,
+              color: Colors.green.lerp(theme.colorScheme.onSurface, 0.3),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              'Selected ${_isXapk ? "XAPK" : "APK"}: $_selectedFileName',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.green.lerp(theme.colorScheme.onSurface, 0.3),
+              ),
+            ),
+          ],
+        ),
+        if (_isXapk)
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              '(Contains split APKs and/or OBB files)',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.6),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/ui/install_progress_dialog.dart
+++ b/lib/ui/install_progress_dialog.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import '../xapk/xapk_installer.dart';
+
+class InstallProgressDialog extends StatefulWidget {
+  final String fileName;
+  final Future<void> Function(InstallProgressCallback onProgress) installer;
+
+  const InstallProgressDialog({
+    super.key,
+    required this.fileName,
+    required this.installer,
+  });
+
+  static Future<bool?> show({
+    required BuildContext context,
+    required String fileName,
+    required Future<void> Function(InstallProgressCallback onProgress) installer,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => InstallProgressDialog(
+        fileName: fileName,
+        installer: installer,
+      ),
+    );
+  }
+
+  @override
+  State<InstallProgressDialog> createState() => _InstallProgressDialogState();
+}
+
+class _InstallProgressDialogState extends State<InstallProgressDialog> {
+  InstallStage _stage = InstallStage.parsing;
+  String _message = 'Starting installation...';
+  double _progress = 0.0;
+  bool _completed = false;
+  bool _success = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _startInstallation();
+  }
+
+  Future<void> _startInstallation() async {
+    await widget.installer((stage, message, progress) {
+      if (mounted) {
+        setState(() {
+          _stage = stage;
+          _message = message;
+          _progress = progress;
+
+          if (stage == InstallStage.completed) {
+            _completed = true;
+            _success = true;
+          } else if (stage == InstallStage.failed) {
+            _completed = true;
+            _success = false;
+          }
+        });
+      }
+    });
+  }
+
+  IconData _getStageIcon() {
+    switch (_stage) {
+      case InstallStage.parsing:
+        return Icons.folder_zip;
+      case InstallStage.installing:
+        return Icons.install_mobile;
+      case InstallStage.pushingObb:
+        return Icons.cloud_upload;
+      case InstallStage.cleaning:
+        return Icons.cleaning_services;
+      case InstallStage.completed:
+        return Icons.check_circle;
+      case InstallStage.failed:
+        return Icons.error;
+    }
+  }
+
+  Color _getStageColor() {
+    switch (_stage) {
+      case InstallStage.completed:
+        return Colors.green;
+      case InstallStage.failed:
+        return Colors.red;
+      default:
+        return Colors.blue;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: Row(
+        children: [
+          Icon(_getStageIcon(), color: _getStageColor()),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              _completed
+                  ? (_success ? 'Installation Complete' : 'Installation Failed')
+                  : 'Installing ${widget.fileName}',
+              style: const TextStyle(fontSize: 18),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(_message),
+          const SizedBox(height: 16),
+          if (!_completed) ...[
+            LinearProgressIndicator(value: _progress),
+            const SizedBox(height: 8),
+            Text(
+              '${(_progress * 100).toInt()}%',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ],
+      ),
+      actions: _completed
+          ? [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(_success),
+                child: const Text('OK'),
+              ),
+            ]
+          : null,
+    );
+  }
+}

--- a/lib/ui/settings_dialog.dart
+++ b/lib/ui/settings_dialog.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../services/preferences.dart';
+
+class SettingsDialog extends StatefulWidget {
+  final VoidCallback onSettingsChanged;
+
+  const SettingsDialog({super.key, required this.onSettingsChanged});
+
+  static Future<void> show(BuildContext context, {required VoidCallback onSettingsChanged}) {
+    return showDialog(
+      context: context,
+      builder: (context) => SettingsDialog(onSettingsChanged: onSettingsChanged),
+    );
+  }
+
+  @override
+  State<SettingsDialog> createState() => _SettingsDialogState();
+}
+
+class _SettingsDialogState extends State<SettingsDialog> {
+  late bool _showSerialNumber;
+
+  @override
+  void initState() {
+    super.initState();
+    _showSerialNumber = Preferences.showSerialNumber;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Settings'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SwitchListTile(
+            title: const Text('Show Serial Number'),
+            subtitle: const Text('Display device serial number in the device list'),
+            value: _showSerialNumber,
+            onChanged: (value) async {
+              await Preferences.setShowSerialNumber(value);
+              setState(() {
+                _showSerialNumber = value;
+              });
+              widget.onSettingsChanged();
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/util/file_path.dart
+++ b/lib/util/file_path.dart
@@ -44,4 +44,42 @@ class FilePath {
     Log.d("Extracted asset: ${ret.path}");
     return ret;
   }
+
+  /// Create a temporary subdirectory
+  static Future<Directory> createTempSubDir(String name) async {
+    final basePath = await path;
+    final dir = Directory(p.join(basePath, name));
+    await dir.create(recursive: true);
+    Log.d("Created temp subdirectory: ${dir.path}");
+    return dir;
+  }
+
+  /// Cleanup a temporary directory
+  static Future<void> cleanupTempDir(String dirPath) async {
+    try {
+      final dir = Directory(dirPath);
+      if (await dir.exists()) {
+        await dir.delete(recursive: true);
+        Log.d("Cleaned up temp directory: $dirPath");
+      }
+    } catch (e, stackTrace) {
+      Log.w("Failed to cleanup temp directory: $dirPath",
+          error: e, stackTrace: stackTrace);
+    }
+  }
+
+  /// Cleanup all XAPK temporary files
+  static Future<void> cleanupAllXapkTemp() async {
+    try {
+      final basePath = await path;
+      final xapkTempDir = Directory(p.join(basePath, 'xapk_temp'));
+      if (await xapkTempDir.exists()) {
+        await xapkTempDir.delete(recursive: true);
+        Log.i("Cleaned up all XAPK temp files");
+      }
+    } catch (e, stackTrace) {
+      Log.w("Failed to cleanup XAPK temp files",
+          error: e, stackTrace: stackTrace);
+    }
+  }
 }

--- a/lib/xapk/xapk_installer.dart
+++ b/lib/xapk/xapk_installer.dart
@@ -1,0 +1,130 @@
+import '../adb/adb.dart';
+import '../logs/log.dart';
+import 'xapk_parser.dart';
+
+/// Installation progress stage
+enum InstallStage {
+  parsing,
+  installing,
+  pushingObb,
+  cleaning,
+  completed,
+  failed,
+}
+
+/// Installation progress callback
+typedef InstallProgressCallback = void Function(
+  InstallStage stage,
+  String message,
+  double progress,
+);
+
+class XapkInstaller {
+  /// Install XAPK file
+  static Future<void> install({
+    required String xapkPath,
+    required String deviceId,
+    required void Function(String message) onSuccess,
+    required void Function(String error) onFailure,
+    InstallProgressCallback? onProgress,
+  }) async {
+    XapkParseResult? parseResult;
+
+    try {
+      // Stage 1: Parse XAPK
+      onProgress?.call(InstallStage.parsing, 'Parsing XAPK file...', 0.1);
+      Log.i("Starting XAPK installation: $xapkPath");
+
+      parseResult = await XapkParser.parse(xapkPath);
+      Log.i("XAPK parsed: ${parseResult.manifest.packageName}, "
+          "${parseResult.allApkPaths.length} APKs, "
+          "${parseResult.obbFiles.length} OBB files");
+
+      if (parseResult.allApkPaths.isEmpty) {
+        throw Exception('No APK files found in XAPK');
+      }
+
+      // Stage 2: Install APK(s)
+      onProgress?.call(InstallStage.installing, 'Installing APK(s)...', 0.3);
+
+      bool installSuccess = false;
+      String installMessage = '';
+
+      await Adb.installMultiple(
+        filePaths: parseResult.allApkPaths,
+        device: deviceId,
+        onSuccess: (msg) {
+          installSuccess = true;
+          installMessage = msg;
+        },
+        onFailure: (err) {
+          installSuccess = false;
+          installMessage = err;
+        },
+      );
+
+      if (!installSuccess) {
+        throw Exception('APK installation failed: $installMessage');
+      }
+
+      // Stage 3: Push OBB files (if any)
+      if (parseResult.hasObbFiles) {
+        onProgress?.call(
+          InstallStage.pushingObb,
+          'Pushing ${parseResult.obbFiles.length} OBB file(s)...',
+          0.6,
+        );
+
+        final obbFiles = parseResult.obbFiles
+            .map((o) => (localPath: o.localPath, remotePath: o.remotePath))
+            .toList();
+
+        final obbSuccess = await Adb.pushObbFiles(
+          files: obbFiles,
+          device: deviceId,
+          onProgress: (current, total, fileName) {
+            const baseProgress = 0.6;
+            final obbProgress = (current / total) * 0.3;
+            onProgress?.call(
+              InstallStage.pushingObb,
+              'Pushing OBB ($current/$total): $fileName',
+              baseProgress + obbProgress,
+            );
+          },
+        );
+
+        if (!obbSuccess) {
+          // OBB push failed, but APK is installed, give warning instead of failure
+          Log.w("OBB files push failed, app may not work correctly");
+          onProgress?.call(
+            InstallStage.completed,
+            'App installed but OBB files failed to push',
+            1.0,
+          );
+          onSuccess('App installed (Warning: OBB files failed to push)');
+          return;
+        }
+      }
+
+      // Stage 4: Cleanup
+      onProgress?.call(InstallStage.cleaning, 'Cleaning up...', 0.95);
+      await XapkParser.cleanup(parseResult);
+
+      // Completed
+      onProgress?.call(InstallStage.completed, 'Installation completed!', 1.0);
+      final message = parseResult.hasObbFiles
+          ? 'App and OBB files installed successfully!'
+          : 'App installed successfully!';
+      onSuccess(message);
+    } catch (e, stackTrace) {
+      Log.e("XAPK installation failed", error: e, stackTrace: stackTrace);
+      onProgress?.call(InstallStage.failed, 'Installation failed: $e', 0.0);
+      onFailure('Installation failed: $e');
+
+      // Cleanup temporary files
+      if (parseResult != null) {
+        await XapkParser.cleanup(parseResult);
+      }
+    }
+  }
+}

--- a/lib/xapk/xapk_manifest.dart
+++ b/lib/xapk/xapk_manifest.dart
@@ -1,0 +1,96 @@
+/// XAPK manifest.json data model
+class XapkManifest {
+  final String packageName;
+  final String? versionName;
+  final int? versionCode;
+  final String? name;
+  final List<String> splitApks;
+  final List<XapkObbFile> obbFiles;
+  final List<XapkExpansion> expansions;
+
+  XapkManifest({
+    required this.packageName,
+    this.versionName,
+    this.versionCode,
+    this.name,
+    this.splitApks = const [],
+    this.obbFiles = const [],
+    this.expansions = const [],
+  });
+
+  factory XapkManifest.fromJson(Map<String, dynamic> json) {
+    return XapkManifest(
+      packageName: json['package_name'] as String,
+      versionName: json['version_name']?.toString(),
+      versionCode: _parseVersionCode(json['version_code']),
+      name: json['name'] as String?,
+      splitApks: _parseSplitApks(json),
+      obbFiles: _parseObbFiles(json),
+      expansions: _parseExpansions(json),
+    );
+  }
+
+  static int? _parseVersionCode(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String) return int.tryParse(value);
+    return null;
+  }
+
+  static List<String> _parseSplitApks(Map<String, dynamic> json) {
+    final splitApks = json['split_apks'] as List<dynamic>?;
+    if (splitApks == null) return [];
+    return splitApks
+        .map((e) => e is Map ? e['file'] as String? : e as String?)
+        .whereType<String>()
+        .toList();
+  }
+
+  static List<XapkObbFile> _parseObbFiles(Map<String, dynamic> json) {
+    final obbFiles = json['obb_files'] as List<dynamic>?;
+    if (obbFiles != null) {
+      return obbFiles
+          .map((e) => XapkObbFile.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    return [];
+  }
+
+  static List<XapkExpansion> _parseExpansions(Map<String, dynamic> json) {
+    final expansions = json['expansions'] as List<dynamic>?;
+    if (expansions == null) return [];
+    return expansions
+        .map((e) => XapkExpansion.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}
+
+class XapkObbFile {
+  final String file;
+  final String installPath;
+
+  XapkObbFile({required this.file, required this.installPath});
+
+  factory XapkObbFile.fromJson(Map<String, dynamic> json) {
+    return XapkObbFile(
+      file: json['file'] as String,
+      installPath: json['install_path'] as String? ??
+          json['install_location'] as String? ??
+          '',
+    );
+  }
+}
+
+class XapkExpansion {
+  final String file;
+  final String installPath;
+
+  XapkExpansion({required this.file, required this.installPath});
+
+  factory XapkExpansion.fromJson(Map<String, dynamic> json) {
+    return XapkExpansion(
+      file: json['file'] as String,
+      installPath: json['install_path'] as String? ?? '',
+    );
+  }
+}

--- a/lib/xapk/xapk_parser.dart
+++ b/lib/xapk/xapk_parser.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:archive/archive.dart';
+import 'package:path/path.dart' as p;
+import '../logs/log.dart';
+import '../util/file_path.dart';
+import 'xapk_manifest.dart';
+
+/// XAPK parse result
+class XapkParseResult {
+  final XapkManifest manifest;
+  final String extractDir;
+  final String? baseApkPath;
+  final List<String> splitApkPaths;
+  final List<XapkObbExtracted> obbFiles;
+
+  XapkParseResult({
+    required this.manifest,
+    required this.extractDir,
+    this.baseApkPath,
+    this.splitApkPaths = const [],
+    this.obbFiles = const [],
+  });
+
+  /// Get all APK file paths (for install-multiple)
+  List<String> get allApkPaths {
+    final paths = <String>[];
+    if (baseApkPath != null) paths.add(baseApkPath!);
+    paths.addAll(splitApkPaths);
+    return paths;
+  }
+
+  /// Whether install-multiple is needed
+  bool get requiresMultipleInstall => allApkPaths.length > 1;
+
+  /// Whether OBB files are present
+  bool get hasObbFiles => obbFiles.isNotEmpty;
+}
+
+class XapkObbExtracted {
+  final String localPath;
+  final String remotePath;
+
+  XapkObbExtracted({required this.localPath, required this.remotePath});
+}
+
+class XapkParser {
+  /// Parse XAPK file
+  static Future<XapkParseResult> parse(String xapkPath) async {
+    Log.i("Starting XAPK parse: $xapkPath");
+
+    // 1. Create unique extract directory
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final xapkName = p.basenameWithoutExtension(xapkPath);
+    final extractDir = await _createExtractDir('xapk_${xapkName}_$timestamp');
+
+    try {
+      // 2. Read XAPK file (ZIP format)
+      final bytes = await File(xapkPath).readAsBytes();
+      final archive = ZipDecoder().decodeBytes(bytes);
+
+      // 3. Parse manifest.json
+      final manifest = await _parseManifest(archive);
+      Log.i("Parsed manifest: package=${manifest.packageName}");
+
+      // 4. Extract APK files
+      String? baseApkPath;
+      final splitApkPaths = <String>[];
+      final obbFiles = <XapkObbExtracted>[];
+
+      // Track which split apks we've already extracted
+      final extractedSplits = <String>{};
+
+      for (final file in archive.files) {
+        if (file.isFile) {
+          final fileName = file.name.toLowerCase();
+          final baseName = p.basename(file.name).toLowerCase();
+
+          if (baseName == 'base.apk' ||
+              (fileName.endsWith('.apk') && baseName.contains('base'))) {
+            // base.apk
+            baseApkPath = await _extractFile(file, extractDir);
+            Log.d("Extracted base APK: $baseApkPath");
+          } else if (fileName.endsWith('.apk')) {
+            // Split APK
+            final path = await _extractFile(file, extractDir);
+            splitApkPaths.add(path);
+            extractedSplits.add(baseName);
+            Log.d("Extracted split APK: $path");
+          } else if (fileName.endsWith('.obb')) {
+            // OBB file
+            final localPath = await _extractFile(file, extractDir);
+            final remotePath = _buildObbRemotePath(
+              manifest.packageName,
+              file.name,
+              manifest.obbFiles,
+            );
+            obbFiles.add(XapkObbExtracted(
+              localPath: localPath,
+              remotePath: remotePath,
+            ));
+            Log.d("Extracted OBB: $localPath -> $remotePath");
+          }
+        }
+      }
+
+      // Handle split_apks from manifest that weren't extracted yet
+      for (final splitName in manifest.splitApks) {
+        if (extractedSplits.contains(splitName.toLowerCase())) continue;
+
+        for (final archiveFile in archive.files) {
+          final baseName = p.basename(archiveFile.name).toLowerCase();
+          if (baseName == splitName.toLowerCase() ||
+              archiveFile.name.toLowerCase().endsWith('/$splitName'.toLowerCase())) {
+            if (archiveFile.size > 0) {
+              final path = await _extractFile(archiveFile, extractDir);
+              splitApkPaths.add(path);
+              Log.d("Extracted additional split APK: $path");
+            }
+            break;
+          }
+        }
+      }
+
+      // Handle expansions (alternative OBB format)
+      for (final expansion in manifest.expansions) {
+        for (final archiveFile in archive.files) {
+          if (p.basename(archiveFile.name).toLowerCase() ==
+              expansion.file.toLowerCase()) {
+            final localPath = await _extractFile(archiveFile, extractDir);
+            obbFiles.add(XapkObbExtracted(
+              localPath: localPath,
+              remotePath: expansion.installPath.isNotEmpty
+                  ? expansion.installPath
+                  : '/sdcard/Android/obb/${manifest.packageName}/${expansion.file}',
+            ));
+            Log.d("Extracted expansion: $localPath");
+            break;
+          }
+        }
+      }
+
+      return XapkParseResult(
+        manifest: manifest,
+        extractDir: extractDir,
+        baseApkPath: baseApkPath,
+        splitApkPaths: splitApkPaths,
+        obbFiles: obbFiles,
+      );
+    } catch (e, stackTrace) {
+      Log.e("Failed to parse XAPK", error: e, stackTrace: stackTrace);
+      // Cleanup extract directory
+      await _cleanupDir(extractDir);
+      rethrow;
+    }
+  }
+
+  static Future<XapkManifest> _parseManifest(Archive archive) async {
+    final manifestFile = archive.files.firstWhere(
+      (f) => f.name.toLowerCase() == 'manifest.json',
+      orElse: () => throw const FormatException('manifest.json not found in XAPK'),
+    );
+
+    final content = utf8.decode(manifestFile.content as List<int>);
+    final json = jsonDecode(content) as Map<String, dynamic>;
+    return XapkManifest.fromJson(json);
+  }
+
+  static Future<String> _createExtractDir(String name) async {
+    final basePath = await FilePath.path;
+    final dir = Directory(p.join(basePath, 'xapk_temp', name));
+    await dir.create(recursive: true);
+    return dir.path;
+  }
+
+  static Future<String> _extractFile(ArchiveFile file, String extractDir) async {
+    final filePath = p.join(extractDir, p.basename(file.name));
+    final outFile = File(filePath);
+    await outFile.writeAsBytes(file.content as List<int>);
+    return filePath;
+  }
+
+  static String _buildObbRemotePath(
+    String packageName,
+    String fileName,
+    List<XapkObbFile> obbManifest,
+  ) {
+    // Try to get path from manifest first
+    for (final obb in obbManifest) {
+      if (fileName.contains(obb.file)) {
+        return obb.installPath;
+      }
+    }
+    // Default OBB path format
+    return '/sdcard/Android/obb/$packageName/${p.basename(fileName)}';
+  }
+
+  static Future<void> _cleanupDir(String dirPath) async {
+    try {
+      final dir = Directory(dirPath);
+      if (await dir.exists()) {
+        await dir.delete(recursive: true);
+        Log.d("Cleaned up directory: $dirPath");
+      }
+    } catch (e) {
+      Log.w("Failed to cleanup directory: $dirPath", error: e);
+    }
+  }
+
+  /// Cleanup parse result temporary files
+  static Future<void> cleanup(XapkParseResult result) async {
+    await _cleanupDir(result.extractDir);
+  }
+}

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import desktop_drop
 import path_provider_foundation
 import screen_retriever_macos
+import shared_preferences_foundation
 import url_launcher_macos
 import window_manager
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,6 +7,9 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
@@ -17,6 +20,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
@@ -29,6 +33,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   url_launcher_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_manager:
@@ -39,6 +45,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,47 @@
+PODS:
+  - desktop_drop (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - screen_retriever_macos (0.0.1):
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+  - window_manager (0.2.0):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
+
+EXTERNAL SOURCES:
+  desktop_drop:
+    :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  screen_retriever_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
+
+SPEC CHECKSUMS:
+  desktop_drop: e0b672a7d84c0a6cbc378595e82cdb15f2970a43
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		02C94C74F16C662FFA56B19C /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4016DDA229B849E2A038322 /* Pods_RunnerTests.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		DAD7E1B3CB5561DE6B3E0D78 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 206393CC56FE7C394ECB8AAA /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		206393CC56FE7C394ECB8AAA /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* android_sideloader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "android_sideloader.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* android_sideloader.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = android_sideloader.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +79,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		42A6F7F2F6690225BAF940D1 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		6C695D530D3122964EB8855C /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		75AB9495D2D9DCD781EAD6B3 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9EBA04C6978B918A909E4FBE /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		D11E1C9EC3CC086DC543BC89 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		E4016DDA229B849E2A038322 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F87D403F4D74182E4573F6DE /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02C94C74F16C662FFA56B19C /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,12 +103,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAD7E1B3CB5561DE6B3E0D78 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		06CF5D09F8ACEE81F4E827A8 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F87D403F4D74182E4573F6DE /* Pods-Runner.debug.xcconfig */,
+				75AB9495D2D9DCD781EAD6B3 /* Pods-Runner.release.xcconfig */,
+				9EBA04C6978B918A909E4FBE /* Pods-Runner.profile.xcconfig */,
+				6C695D530D3122964EB8855C /* Pods-RunnerTests.debug.xcconfig */,
+				42A6F7F2F6690225BAF940D1 /* Pods-RunnerTests.release.xcconfig */,
+				D11E1C9EC3CC086DC543BC89 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C80D6294CF71000263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +151,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				06CF5D09F8ACEE81F4E827A8 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,6 +202,8 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				206393CC56FE7C394ECB8AAA /* Pods_Runner.framework */,
+				E4016DDA229B849E2A038322 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				46CE48A83866D7887A59E281 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				1D3665ACBE3E1BB92A3F9598 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				7AFE94B25157615DDF0E080F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,6 +323,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1D3665ACBE3E1BB92A3F9598 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +382,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		46CE48A83866D7887A59E281 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7AFE94B25157615DDF0E080F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6C695D530D3122964EB8855C /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42A6F7F2F6690225BAF940D1 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D11E1C9EC3CC086DC543BC89 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -461,7 +557,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -543,7 +639,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -593,7 +689,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   file_picker:
     dependency: "direct main"
     description:
@@ -384,6 +392,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: cbc40be9be1c5af4dab4d6e0de4d5d3729e6f3d65b89d21e1815d57705644a6f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.20"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -582,5 +646,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.27.1"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,13 +2,13 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
-      sha256: "6199c74e3db4fbfbd04f66d739e72fe11c8a8957d5f219f1f4482dbde6420b5a"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "3.6.1"
   args:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -61,18 +61,18 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cross_file:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "8346ad4b5173924b5ddddab782fc7d8a6300178c8b1dc427775405a01701c4a6"
+      sha256: f31d52537dc417fdcde36088fdf11d191026fd5e4fae742491ebd40e5a8bea7d
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.3.0"
   json_annotation:
     dependency: transitive
     description:
@@ -188,26 +188,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -228,10 +228,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -244,18 +244,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -328,14 +328,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  posix:
-    dependency: transitive
-    description:
-      name: posix
-      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.1"
   process_run:
     dependency: "direct main"
     description:
@@ -409,18 +401,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -449,10 +441,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:
@@ -529,10 +521,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -590,5 +582,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.27.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_launcher_icons: ^0.14.2
   crypto: ^3.0.6
   url_launcher: ^6.3.1
+  archive: ^3.6.1
 
 
   # The following adds the Cupertino Icons font to your application.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   crypto: ^3.0.6
   url_launcher: ^6.3.1
   archive: ^3.6.1
-
+  shared_preferences: ^2.2.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/scripts/get-release-notes.sh
+++ b/scripts/get-release-notes.sh
@@ -17,16 +17,16 @@ fi
 
 CHANGELOG_CONTENT=$(cat "$CHANGELOG_PATH")
 
-PATTERN="## \[$VERSION_NAME.*?\](.*?)(?=## \[|\$)"
-
 RELEASE_NOTES=$(echo "$CHANGELOG_CONTENT" | \
-  perl -0777 -ne "if (/($PATTERN)/s) { print \$1; exit 0 }")
+  VERSION="$VERSION_NAME" perl -0777 -ne 'my $ver = $ENV{VERSION}; if (/## \[\Q$ver\E[^\]]*\].*?\n(.*?)(?=## \[|\z)/s) { print $1; }')
 
 if [ -n "$RELEASE_NOTES" ]; then
   echo "$RELEASE_NOTES" | sed 's/\r//g'
 else
-  echo "Error: Release notes for version '$VERSION_NAME' not found."
-  exit 1
+  # For pre-release/beta versions or missing changelog entries, provide a default message
+  echo "Release $VERSION_NAME"
+  echo ""
+  echo "See the full changelog at: https://github.com/allea/Android-SideHustle/blob/main/CHANGELOG.md"
 fi
 
 exit 0


### PR DESCRIPTION
.XAPK support (as many apps now won't be able to install properly after the XAPK -> APK conversion):

- Parse XAPK format (ZIP containing split APKs, OBB files, manifest.json)
- Install split APKs via adb install-multiple
- Push OBB expansion files to device storage
- Show progress dialog during XAPK installation
- Support drag-and-drop for .xapk files
- Handle version_code as both int and string in manifest

Details documented here: docs/changelogs/xapk-support.md

---

Didn't test with tons of the .xapk; but for the one I was trying it's nicely installed:


<img width="912" height="712" alt="截屏2026-01-31 22 58 57" src="https://github.com/user-attachments/assets/f358591f-6825-40a6-86e0-33c50b448b58" />

